### PR TITLE
Hidden logo on non-sticky header

### DIFF
--- a/website/components/Header/index.tsx
+++ b/website/components/Header/index.tsx
@@ -144,7 +144,7 @@ const Header = () => {
               <Link
                 href="/"
                 className={`header-logo block w-full ${
-                  sticky ? "py-2 lg:py-2" : "py-3"
+                  sticky ? "py-2 lg:py-2 block w-full" : "py-3 hidden"
                 }`}
               >
                 <Image


### PR DESCRIPTION
The logo on the non sticky header was overlapping with the logo on the slider banners. So ive made it hidden, to appear only on the sticky header

# Prerequisites

- [x] I am done with the given task
- [x] I am sure that I have hit the needs of the task
- [x] I am confident that it is working as expected
- [x] In its stage it can hit the production
